### PR TITLE
add i18n support with japanese language option

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,6 +12,8 @@ rm -rf build/js/MathJax
 # weaver only copies flat files from js/ and css/ so we do a full recursive copy for subdirs
 cp -r js/libs build/js/libs
 cp -r css/libs build/css/libs
+# copy the i18n strings file to the build root
+cp source/strings.json build/strings.json
 mv gitbak build/.git
 cd build
 echo $FRONTEND_ROOT > CNAME

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,23 @@
+rm -rf build
+git clone $FRONTEND_URL build
+cd build
+git checkout gh-pages
+cd ..
+mv build/.git gitbak
+rm -rf build
+mkdir -p build/weaver
+sleep 2
+bundle exec weaver build --root=$FRONTEND_ROOT
+rm -rf build/js/MathJax
+# weaver only copies flat files from js/ and css/ so we do a full recursive copy for subdirs
+cp -r js/libs build/js/libs
+cp -r css/libs build/css/libs
+# copy the i18n strings file to the build root
+cp source/strings.json build/strings.json
+mv gitbak build/.git
+cd build
+echo $FRONTEND_ROOT > CNAME
+git add .
+git commit -m "update"
+git push
+cd ..

--- a/js/controls.js
+++ b/js/controls.js
@@ -23,13 +23,13 @@ function queue_song(song_code) {
             contentType: "application/json; charset=utf-8"
         }).then(function(data) {
             $("#song-modal").modal("hide");
-            toast("Sent to queue", "toast-green");
+            toast(i18n("toast_sent_to_queue"), "toast-green");
             append_history(song_code);
         });
     } else {
         const toast_text = !session_is_active() ?
-            "Not connected" :
-            "Invalid song code";
+            i18n("toast_not_connected") :
+            i18n("toast_invalid_song_code");
         $("#song-modal").modal("hide");
         toast(toast_text, "toast-red");
     }
@@ -60,7 +60,7 @@ function stop_song() {
         }),
         contentType: "application/json; charset=utf-8"
     }).then(function(data) {
-        toast("Sent stop request", "toast-green");
+        toast(i18n("toast_sent_stop_request"), "toast-green");
     });
 }
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,116 @@
+/*
+ * +------------------------------------------------------------
+ * | i18n.js
+ * +------------------------------------------------------------
+ * | loads UI strings from strings.json and exposes the i18n()
+ * | helper used to retrieve strings in the active language.
+ * | Active language is read from localStorage (key: "language")
+ * | with "en" as the default. Any element marked with a
+ * | data-i18n attribute (or data-i18n-placeholder /
+ * | data-i18n-html / data-i18n-value) is substituted by
+ * | apply_translations() at startup time.
+ * +------------------------------------------------------------
+ */
+
+// Global string table populated by load_strings().
+let STRINGS = {};
+
+// Returns the currently selected language code ("en" or "ja").
+function current_language() {
+    return localStorage.getItem("language") === "ja" ? "ja" : "en";
+}
+
+// Returns the localized string for the given key. If the key is
+// missing it returns the key itself so missing translations are
+// visible. `vars` allows {placeholder} substitution in the value.
+function i18n(key, vars) {
+    const entry = STRINGS[key];
+    let value;
+    if (!entry || typeof entry !== "object") {
+        value = key;
+    } else {
+        value = entry[current_language()] ?? entry.en ?? key;
+    }
+    if (vars) {
+        Object.keys(vars).forEach(name => {
+            value = value.split(`{${name}}`).join(vars[name]);
+        });
+    }
+    return value;
+}
+
+// Loads strings.json from the site root and caches into STRINGS.
+// Returns a Promise that resolves once the table is ready.
+function load_strings() {
+    return fetch("strings.json", { cache: "no-cache" })
+        .then(r => r.json())
+        .then(data => { STRINGS = data; })
+        .catch(err => {
+            console.error("Failed to load strings.json", err);
+            STRINGS = {};
+        });
+}
+
+// Walks the DOM and replaces text content / placeholders / html /
+// value for any element marked with a data-i18n* attribute.
+// Also translates weaver-rendered tab nav links using a stable key map.
+// Safe to call multiple times (e.g. on language change).
+function apply_translations(root) {
+    const scope = root || document;
+    scope.querySelectorAll("[data-i18n]").forEach(el => {
+        el.textContent = i18n(el.getAttribute("data-i18n"));
+    });
+    scope.querySelectorAll("[data-i18n-html]").forEach(el => {
+        el.innerHTML = i18n(el.getAttribute("data-i18n-html"));
+    });
+    scope.querySelectorAll("[data-i18n-placeholder]").forEach(el => {
+        el.setAttribute("placeholder", i18n(el.getAttribute("data-i18n-placeholder")));
+    });
+    scope.querySelectorAll("[data-i18n-value]").forEach(el => {
+        el.setAttribute("value", i18n(el.getAttribute("data-i18n-value")));
+    });
+    // data-i18n-btn: translates the text node inside a button element
+    scope.querySelectorAll("[data-i18n-btn]").forEach(el => {
+        // buttons may contain an icon element — only update the text node
+        const key = el.getAttribute("data-i18n-btn");
+        const text_node = Array.from(el.childNodes).find(n => n.nodeType === Node.TEXT_NODE);
+        if (text_node) {
+            text_node.textContent = i18n(key);
+        } else {
+            el.textContent = i18n(key);
+        }
+    });
+    // data-i18n-checkbox: translates the label text next to a checkbox input
+    scope.querySelectorAll("[data-i18n-checkbox]").forEach(el => {
+        const key = el.getAttribute("data-i18n-checkbox");
+        // weaver renders checkboxes as <label><input>Label text</label> or similar
+        // update the text node inside the label (leaving any child inputs intact)
+        const label = el.closest("label") || el.querySelector("label") || el;
+        const text_node = Array.from(label.childNodes).find(n => n.nodeType === Node.TEXT_NODE && n.textContent.trim());
+        if (text_node) {
+            text_node.textContent = " " + i18n(key);
+        } else {
+            label.textContent = i18n(key);
+        }
+    });
+
+    // Translate weaver tab nav links. Weaver renders tabs as plain <a> text
+    // inside a nav, so we patch them by their stable English label using a
+    // lookup table keyed by the English text we know was rendered at build time.
+    const tab_keys = {
+        "Search":     "tab_search",
+        "History":    "tab_history",
+        "Favourites": "tab_favourites",
+        "Advanced":   "tab_advanced"
+    };
+    document.querySelectorAll("ul.nav-tabs li a, ul.nav a").forEach(a => {
+        const english = a.getAttribute("data-i18n-original") || a.textContent.trim();
+        if (tab_keys[english]) {
+            // store original English text on first pass so subsequent calls stay stable
+            if (!a.getAttribute("data-i18n-original")) {
+                a.setAttribute("data-i18n-original", english);
+            }
+            a.textContent = i18n(tab_keys[english]);
+        }
+    });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -9,49 +9,68 @@
 
 // loads elements on page start
 function startup() {
-    // add listeners to search bar
-    $(window).keydown(function(event) {
-        if (event.keyCode == 13) {
-            start_search();
-            event.preventDefault();
-            return false;
-        }
-    });
+    // load i18n strings first, then initialise everything else
+    load_strings().then(() => {
+        // apply translations to all data-i18n-marked elements
+        apply_translations();
 
-    // add listeners to populate tabs
-    $("li a:contains('History')").on("click", function() {
-        fill_song_history();
-    });
-    $("li a:contains('Favourites')").on("click", function() {
-        fill_favourites();
-    });
+        // add listeners to search bar
+        $(window).keydown(function(event) {
+            if (event.keyCode == 13) {
+                start_search();
+                event.preventDefault();
+                return false;
+            }
+        });
 
-    // load various settings options
-    set_nickname(true);
-    $("#developer-tools").toggle($('input[name="developer-mode"]').prop('checked'));
-    $('input[name="developer-mode"]').on('ifChecked ifUnchecked', function () {
+        // add listeners to populate tabs
+        // use data-i18n-original (set by apply_translations) for stable selection
+        $("li a[data-i18n-original='History']").on("click", function() {
+            fill_song_history();
+        });
+        $("li a[data-i18n-original='Favourites']").on("click", function() {
+            fill_favourites();
+        });
+
+        // load various settings options
+        set_nickname(true);
         $("#developer-tools").toggle($('input[name="developer-mode"]').prop('checked'));
-    });
-    $('input[name="developer-mode"]').on('ifUnchecked', function () {
-        if (DEBUG_TOAST) { DEBUG_TOAST.hideToast(); }
-        sessionStorage.removeItem("debug_mode");
-    });
+        $('input[name="developer-mode"]').on('ifChecked ifUnchecked', function () {
+            $("#developer-tools").toggle($('input[name="developer-mode"]').prop('checked'));
+        });
+        $('input[name="developer-mode"]').on('ifUnchecked', function () {
+            if (DEBUG_TOAST) { DEBUG_TOAST.hideToast(); }
+            sessionStorage.removeItem("debug_mode");
+        });
 
-    // checks if session is already active
-    update_status(session_is_active());
-    if (!session_is_active()) {
-        show_connection_toast();
-    }
+        // japanese mode: restore from localStorage and listen for changes
+        const japanese_mode = localStorage.getItem("language") === "ja";
+        $('input[name="japanese-mode"]').prop('checked', japanese_mode);
+        $('input[name="japanese-mode"]').on('ifChecked', function () {
+            localStorage.setItem("language", "ja");
+            apply_translations();
+        });
+        $('input[name="japanese-mode"]').on('ifUnchecked', function () {
+            localStorage.setItem("language", "en");
+            apply_translations();
+        });
 
-    // clears forms on reload
-    $(document).ready(function() {
-        // TODO: update these if IDs can be set in weaver
-        $("#song_search_form")[0].reset();
-        $("#queue_code_form")[0].reset();
-    });
+        // checks if session is already active
+        update_status(session_is_active());
+        if (!session_is_active()) {
+            show_connection_toast();
+        }
 
-    // disables debug mode on reload
-    window.addEventListener("beforeunload", () => {
-        sessionStorage.removeItem("debug_mode");
+        // clears forms on reload
+        $(document).ready(function() {
+            // TODO: update these if IDs can be set in weaver
+            $("#song_search_form")[0].reset();
+            $("#queue_code_form")[0].reset();
+        });
+
+        // disables debug mode on reload
+        window.addEventListener("beforeunload", () => {
+            sessionStorage.removeItem("debug_mode");
+        });
     });
 }

--- a/js/main.js
+++ b/js/main.js
@@ -9,61 +9,80 @@
 
 // loads elements on page start
 function startup() {
-    // add listeners to search bar
-    $(window).keydown(function(event) {
-        if (event.keyCode == 13) {
-            start_search();
-            event.preventDefault();
-            return false;
-        }
-    });
+    // load i18n strings first, then initialise everything else
+    load_strings().then(() => {
+        // apply translations to all data-i18n-marked elements
+        apply_translations();
 
-    // handle browser back & mobile back button
-    history.pushState(null, null, location.href);
-    $(window).on('popstate', function(event) {
+        // handle browser back & mobile back button
         history.pushState(null, null, location.href);
-        back_handler();
-    });
+        $(window).on('popstate', function(event) {
+            history.pushState(null, null, location.href);
+            back_handler();
+        });
 
-    // add listeners to tabs
-    $("li a:contains('History')").on("click", function() {
-        fill_song_history();
-    });
-    $("li a:contains('Favourites')").on("click", function() {
-        fill_favourites();
-    });
-    $("#song_search_form input").on("ifChecked", function () {
-        if ($("#search-field").val().trim()) {
-            start_search();
-        }
-    });
+        // add listeners to search bar
+        $(window).keydown(function(event) {
+            if (event.keyCode == 13) {
+                start_search();
+                event.preventDefault();
+                return false;
+            }
+        });
 
-    // load various settings options
-    set_nickname(true);
-    $("#developer-tools").toggle($('input[name="developer-mode"]').prop('checked'));
-    $('input[name="developer-mode"]').on('ifChecked ifUnchecked', function () {
+        // add listeners to populate tabs
+        // use data-i18n-original (set by apply_translations) for stable selection
+        $("li a[data-i18n-original='History']").on("click", function() {
+            fill_song_history();
+        });
+        $("li a[data-i18n-original='Favourites']").on("click", function() {
+            fill_favourites();
+        });
+        $("#song_search_form input").on("ifChecked", function () {
+            if ($("#search-field").val().trim()) {
+                start_search();
+            }
+        });
+
+        // load various settings options
+        set_nickname(true);
         $("#developer-tools").toggle($('input[name="developer-mode"]').prop('checked'));
-    });
-    $('input[name="developer-mode"]').on('ifUnchecked', function () {
-        if (DEBUG_TOAST) { DEBUG_TOAST.hideToast(); }
-        sessionStorage.removeItem("debug_mode");
-    });
+        $('input[name="developer-mode"]').on('ifChecked ifUnchecked', function () {
+            $("#developer-tools").toggle($('input[name="developer-mode"]').prop('checked'));
+        });
+        $('input[name="developer-mode"]').on('ifUnchecked', function () {
+            if (DEBUG_TOAST) { DEBUG_TOAST.hideToast(); }
+            sessionStorage.removeItem("debug_mode");
+        });
 
-    // checks if session is already active
-    update_status(session_is_active());
-    if (!session_is_active()) {
-        show_connection_toast();
-    }
+        // japanese mode: restore from localStorage and listen for changes
+        const japanese_mode = localStorage.getItem("language") === "ja";
+        $('input[name="japanese-mode"]').prop('checked', japanese_mode);
+        $('input[name="japanese-mode"]').on('ifChecked', function () {
+            localStorage.setItem("language", "ja");
+            apply_translations();
+        });
+        $('input[name="japanese-mode"]').on('ifUnchecked', function () {
+            localStorage.setItem("language", "en");
+            apply_translations();
+        });
 
-    // clears forms on reload
-    $(document).ready(function() {
-        // TODO: update these if IDs can be set in weaver
-        $("#song_search_form")[0].reset();
-        $("#queue_code_form")[0].reset();
-    });
+        // checks if session is already active
+        update_status(session_is_active());
+        if (!session_is_active()) {
+            show_connection_toast();
+        }
 
-    // disables debug mode on reload
-    window.addEventListener("beforeunload", () => {
-        sessionStorage.removeItem("debug_mode");
+        // clears forms on reload
+        $(document).ready(function() {
+            // TODO: update these if IDs can be set in weaver
+            $("#song_search_form")[0].reset();
+            $("#queue_code_form")[0].reset();
+        });
+
+        // disables debug mode on reload
+        window.addEventListener("beforeunload", () => {
+            sessionStorage.removeItem("debug_mode");
+        });
     });
 }

--- a/js/session.js
+++ b/js/session.js
@@ -67,13 +67,13 @@ async function scan_success(decoded_text, decoded_result) {
             sessionStorage.setItem("scd", keys[2]);
             sessionStorage.setItem("connected_at", new Date().toLocaleDateString("ja-JP"));
             update_status(true);
-            toast("Connected", "toast-green");
+            toast(i18n("toast_connected"), "toast-green");
         } else {
             throw new Error("Invalid QR Code");
         }
     } catch (error) {
         if (toast_id) return;
-        toast("Invalid QR Code", "toast-red");
+        toast(i18n("toast_invalid_qr"), "toast-red");
         toast_id = setTimeout(() => { toast_id = null; }, TOAST_DURATION);
     }
 }
@@ -83,8 +83,8 @@ function update_status(status) {
     const active = status && session_is_active();
 
     $("#connected").text(active ?
-        `Connected on ${sessionStorage.getItem("connected_at")}` :
-        "Not Connected"
+        i18n("status_connected_on", { date: sessionStorage.getItem("connected_at") }) :
+        i18n("status_not_connected")
     );
 
     $("#random-history, #random-favourite, #add-to-queue")

--- a/js/settings.js
+++ b/js/settings.js
@@ -24,7 +24,7 @@ async function set_nickname(startup = false) {
     $("#nickname-field").val(nickname);
     localStorage.setItem("nickname", nickname);
     if (!startup) {
-        toast("Nickname saved", "toast-green");
+        toast(i18n("toast_nickname_saved"), "toast-green");
     }
 }
 
@@ -43,7 +43,7 @@ function show_info() {
                 most_played_table.append($row);
             }
         );
-        $("#most-played").html($("<h4>").text("Most Played:"));
+        $("#most-played").html($("<h4>").text(i18n("most_played_heading")));
         $("#most-played").append(most_played_table);
     }
     $("#info-modal").modal("show");

--- a/js/utils.js
+++ b/js/utils.js
@@ -45,28 +45,28 @@ function normalize_song(song_code) {
 function build_song_modal_data(song_code) {
     const song_cache = JSON.parse(localStorage.getItem("song_cache"));
     const song_count = JSON.parse(localStorage.getItem("song_count")) ?? {};
-    const song_info = {
-        Title: song_cache[song_code].song,
-        Artist: song_cache[song_code].artist,
-        Genre: song_cache[song_code].extra.genre_name,
-        Info: song_cache[song_code].extra.information ?? 
-            song_cache[song_code].extra.program_name ?? 
-            song_cache[song_code].extra.tie_up,
-        Lyrics: song_cache[song_code].extra?.introcha ?
-            `${song_cache[song_code].extra.introcha}…` : null,
-        "Play Count": song_count[song_code],
-        Code: song_cache[song_code].code
-    };
+    const song_info = [
+        { key: "field_title",      id: "title",      value: song_cache[song_code].song },
+        { key: "field_artist",     id: "artist",     value: song_cache[song_code].artist },
+        { key: "field_genre",      id: "genre",      value: song_cache[song_code].extra.genre_name },
+        { key: "field_info",       id: "info",       value: song_cache[song_code].extra.information ??
+                                                                 song_cache[song_code].extra.program_name ??
+                                                                 song_cache[song_code].extra.tie_up },
+        { key: "field_lyrics",     id: "lyrics",     value: song_cache[song_code].extra?.introcha ?
+                                                                 `${song_cache[song_code].extra.introcha}…` : null },
+        { key: "field_play_count", id: "play-count", value: song_count[song_code] },
+        { key: "field_code",       id: "code",       value: song_cache[song_code].code }
+    ];
     let modal_data = [];
-    Object.keys(song_info).forEach(key => {
-        if (song_info[key]) {
-            modal_data.push($("<h4>").text(`${key}:`));
-            const tag = $("<p>").attr("id", `current-song-${key.toLowerCase()}`);
-            modal_data.push(tag.text(song_info[key]));
+    song_info.forEach(({ key, id, value }) => {
+        if (value) {
+            modal_data.push($("<h4>").text(`${i18n(key)}:`));
+            const tag = $("<p>").attr("id", `current-song-${id}`);
+            modal_data.push(tag.text(value));
         }
     });
     if (sessionStorage.getItem("debug_mode")) {
-        modal_data.push($("<hr>"), $("<h4>").text("Debugging info:"));
+        modal_data.push($("<hr>"), $("<h4>").text(i18n("debugging_info_heading")));
         modal_data.push($("<pre>").text(JSON.stringify(song_cache[song_code], null, 2)));
     }
     return modal_data;
@@ -115,7 +115,7 @@ function toast(message, class_name) {
 
 function show_connection_toast() {
     CONNECTION_TOAST = Toastify({
-        text: "Not connected—scan QR code to get started",
+        text: i18n("toast_not_connected_long"),
         duration: -1,
         position: "center",
         gravity: "bottom",
@@ -126,7 +126,7 @@ function show_connection_toast() {
 
 function show_debug_toast() {
     DEBUG_TOAST = Toastify({
-        text: "🐞 Debugging Enabled",
+        text: i18n("toast_debug_enabled"),
         duration: -1,
         position: "center",
         className: "toast-yellow",

--- a/js/utils.js
+++ b/js/utils.js
@@ -46,28 +46,28 @@ function normalize_song(song_code) {
 function build_song_modal_data(song_code) {
     const song_cache = JSON.parse(localStorage.getItem("song_cache"));
     const song_count = JSON.parse(localStorage.getItem("song_count")) ?? {};
-    const song_info = {
-        Title: song_cache[song_code].song,
-        Artist: song_cache[song_code].artist,
-        Genre: song_cache[song_code].extra.genre_name,
-        Info: song_cache[song_code].extra.information ?? 
-            song_cache[song_code].extra.program_name ?? 
-            song_cache[song_code].extra.tie_up,
-        Lyrics: song_cache[song_code].extra?.introcha ?
-            `${song_cache[song_code].extra.introcha}…` : null,
-        "Play Count": song_count[song_code],
-        Code: song_cache[song_code].code
-    };
+    const song_info = [
+        { key: "field_title",      id: "title",      value: song_cache[song_code].song },
+        { key: "field_artist",     id: "artist",     value: song_cache[song_code].artist },
+        { key: "field_genre",      id: "genre",      value: song_cache[song_code].extra.genre_name },
+        { key: "field_info",       id: "info",       value: song_cache[song_code].extra.information ??
+                                                                 song_cache[song_code].extra.program_name ??
+                                                                 song_cache[song_code].extra.tie_up },
+        { key: "field_lyrics",     id: "lyrics",     value: song_cache[song_code].extra?.introcha ?
+                                                                 `${song_cache[song_code].extra.introcha}…` : null },
+        { key: "field_play_count", id: "play-count", value: song_count[song_code] },
+        { key: "field_code",       id: "code",       value: song_cache[song_code].code }
+    ];
     let modal_data = [];
-    Object.keys(song_info).forEach(key => {
-        if (song_info[key]) {
-            modal_data.push($("<h4>").text(`${key}:`));
-            const tag = $("<p>").attr("id", `current-song-${key.toLowerCase()}`);
-            modal_data.push(tag.text(song_info[key]));
+    song_info.forEach(({ key, id, value }) => {
+        if (value) {
+            modal_data.push($("<h4>").text(`${i18n(key)}:`));
+            const tag = $("<p>").attr("id", `current-song-${id}`);
+            modal_data.push(tag.text(value));
         }
     });
     if (sessionStorage.getItem("debug_mode")) {
-        modal_data.push($("<hr>"), $("<h4>").text("Debugging info:"));
+        modal_data.push($("<hr>"), $("<h4>").text(i18n("debugging_info_heading")));
         modal_data.push($("<pre>").text(JSON.stringify(song_cache[song_code], null, 2)));
     }
     return modal_data;
@@ -135,7 +135,7 @@ function toast(message, class_name) {
 
 function show_connection_toast() {
     CONNECTION_TOAST = Toastify({
-        text: "Not connected—scan QR code to get started",
+        text: i18n("toast_not_connected_long"),
         duration: -1,
         position: "center",
         gravity: "bottom",
@@ -146,7 +146,7 @@ function show_connection_toast() {
 
 function show_debug_toast() {
     DEBUG_TOAST = Toastify({
-        text: "🐞 Debugging Enabled",
+        text: i18n("toast_debug_enabled"),
         duration: -1,
         position: "center",
         className: "toast-yellow",

--- a/source/index.weave
+++ b/source/index.weave
@@ -4,20 +4,6 @@ require 'json'
 # Load all UI strings from the project root
 _strings = JSON.parse(File.read(File.join(__dir__, 'strings.json')))
 
-# Helper: returns the English text for a key (used as weaver string arguments)
-# and renders a <span data-i18n="key"> so JS can swap to Japanese at runtime.
-def s(strings, key)
-  en = strings.dig(key, 'en') || key
-  "<span data-i18n=\"#{key}\">#{en}</span>"
-end
-
-# Plain English text for arguments that weaver renders as HTML attributes
-# (e.g. tab names, button labels) — weaver wraps these itself so we use spans.
-# For truly plain-text-only contexts we fall back to the English string directly.
-def t(strings, key)
-  strings.dig(key, 'en') || key
-end
-
 empty_page "", "alesap.blankaex.reisen", theme: :dark do
     #
     # Imports
@@ -42,11 +28,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     # Content
     #
     tabs do
-        tab t(_strings, "tab_search") do
-            h4 s(_strings, "song_search_heading")
+        tab "#{_strings.dig('tab_search', 'en') || 'tab_search'}" do
+            h4 "<span data-i18n=\"song_search_heading\">#{_strings.dig('song_search_heading', 'en') || 'song_search_heading'}</span>"
             wform id: "song_search_form" do
-                textfield "search", nil, placeholder: t(_strings, "search_placeholder"), id: "search-field", "data-i18n-placeholder": "search_placeholder"
-                submit t(_strings, "search_button"), :search, id: "search-button", "data-i18n-value": "search_button" do
+                textfield "search", nil, placeholder: "#{_strings.dig('search_placeholder', 'en') || 'search_placeholder'}", id: "search-field", "data-i18n-placeholder": "search_placeholder"
+                submit "#{_strings.dig('search_button', 'en') || 'search_button'}", :search, id: "search-button", "data-i18n-value": "search_button" do
                     script "start_search();"
                 end
                 normal_button :stop, nil, id: "stop-playback", style: "danger", css_style: "display: none;" do
@@ -54,14 +40,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 end
             end
             small id: "search-help" do
-                a s(_strings, "search_help_link"), href: "javascript:$('#search-help-modal').modal('show');;"
+                a "<span data-i18n=\"search_help_link\">#{_strings.dig('search_help_link', 'en') || 'search_help_link'}</span>", href: "javascript:$('#search-help-modal').modal('show');;"
             end
             # wrap table in div to avoid conflicts with pagination element
             div do
                 table striped: true, id: "song-table", style: "display: none;" do
                     thead id: "song-table-head" do
-                        th { text s(_strings, "column_title") }
-                        th { text s(_strings, "column_artist") }
+                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
                     end
                     tbody id: "song-table-body" do
                     end
@@ -69,7 +55,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "empty-search", style: "display: none;" do
                 jumbotron do
-                  span s(_strings, "empty_search")
+                  span "<span data-i18n=\"empty_search\">#{_strings.dig('empty_search', 'en') || 'empty_search'}</span>"
                 end
             end
             div id: "loader-div" do
@@ -78,23 +64,23 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab t(_strings, "tab_history") do
+        tab "#{_strings.dig('tab_history', 'en') || 'tab_history'}" do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-history" do
                 jumbotron do
-                    p s(_strings, "empty_history_title")
-                    span s(_strings, "empty_history_subtitle")
+                    p "<span data-i18n=\"empty_history_title\">#{_strings.dig('empty_history_title', 'en') || 'empty_history_title'}</span>"
+                    span "<span data-i18n=\"empty_history_subtitle\">#{_strings.dig('empty_history_subtitle', 'en') || 'empty_history_subtitle'}</span>"
                 end
             end
             div id: "history", style: "display: none;" do
-                block_button :magic, t(_strings, "feeling_lucky"), id: "random-history", style: "none" do
+                block_button :magic, "#{_strings.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-history", style: "none" do
                     script "queue_random('history');"
                 end
                 table striped: true, id: "history-table" do
                     thead id: "history-table-head" do
-                        th { text s(_strings, "column_title") }
-                        th { text s(_strings, "column_artist") }
-                        th { text s(_strings, "column_last_played") }
+                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
+                        th { text "<span data-i18n=\"column_last_played\">#{_strings.dig('column_last_played', 'en') || 'column_last_played'}</span>" }
                     end
                     tbody id: "history-table-body" do
                     end
@@ -102,22 +88,22 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab t(_strings, "tab_favourites") do
+        tab "#{_strings.dig('tab_favourites', 'en') || 'tab_favourites'}" do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-favourites" do
                 jumbotron do
-                    p s(_strings, "empty_favourites_title")
-                    span s(_strings, "empty_favourites_subtitle")
+                    p "<span data-i18n=\"empty_favourites_title\">#{_strings.dig('empty_favourites_title', 'en') || 'empty_favourites_title'}</span>"
+                    span "<span data-i18n=\"empty_favourites_subtitle\">#{_strings.dig('empty_favourites_subtitle', 'en') || 'empty_favourites_subtitle'}</span>"
                 end
             end
             div id: "favourites", style: "display: none;" do
-                block_button :magic, t(_strings, "feeling_lucky"), id: "random-favourite", style: "none" do
+                block_button :magic, "#{_strings.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-favourite", style: "none" do
                     script "queue_random('favourites');"
                 end
                 table striped: true, id: "favourites-table" do
                     thead id: "favourites-table-head" do
-                        th { text s(_strings, "column_title") }
-                        th { text s(_strings, "column_artist") }
+                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
                     end
                     tbody id: "favourites-table-body" do
                     end
@@ -125,26 +111,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab t(_strings, "tab_advanced") do
+        tab "#{_strings.dig('tab_advanced', 'en') || 'tab_advanced'}" do
             ibox do
                 type :panel
-                title t(_strings, "settings_title")
+                title "#{_strings.dig('settings_title', 'en') || 'settings_title'}"
                 div id: "settings" do
-                    h4 s(_strings, "nickname_heading")
+                    h4 "<span data-i18n=\"nickname_heading\">#{_strings.dig('nickname_heading', 'en') || 'nickname_heading'}</span>"
                     wform id: "nickname_form" do
                         textfield "nickname", nil, id: "nickname-field"
-                        submit t(_strings, "set_nickname_button"), :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
+                        submit "#{_strings.dig('set_nickname_button', 'en') || 'set_nickname_button'}", :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
                             script "set_nickname(false);"
                         end
                     end
-                    h4 s(_strings, "options_heading")
+                    h4 "<span data-i18n=\"options_heading\">#{_strings.dig('options_heading', 'en') || 'options_heading'}</span>"
                     wform id: "developer_mode_form" do
-                        checkbox "developer-mode", t(_strings, "enable_developer_tools"), id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
-                        checkbox "japanese-mode", t(_strings, "enable_japanese"), id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
+                        checkbox "developer-mode", "#{_strings.dig('enable_developer_tools', 'en') || 'enable_developer_tools'}", id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
+                        checkbox "japanese-mode", "#{_strings.dig('enable_japanese', 'en') || 'enable_japanese'}", id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
                     end
-                    h4 s(_strings, "info_heading")
+                    h4 "<span data-i18n=\"info_heading\">#{_strings.dig('info_heading', 'en') || 'info_heading'}</span>"
                     div do
-                        block_button nil, t(_strings, "show_info_button"), id: "show-info", "data-i18n-btn": "show_info_button" do
+                        block_button nil, "#{_strings.dig('show_info_button', 'en') || 'show_info_button'}", id: "show-info", "data-i18n-btn": "show_info_button" do
                             script "show_info();"
                         end
                     end
@@ -152,38 +138,38 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             ibox do
                 type :panel
-                title t(_strings, "queue_song_by_code")
+                title "#{_strings.dig('queue_song_by_code', 'en') || 'queue_song_by_code'}"
                 # TODO: weaver breaks when form ids contain - (changes function name)
                 wform id: "queue_code_form" do
-                    textfield "ecd", nil, placeholder: t(_strings, "song_code_placeholder"), id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
-                    submit t(_strings, "add_to_queue_button"), :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
+                    textfield "ecd", nil, placeholder: "#{_strings.dig('song_code_placeholder', 'en') || 'song_code_placeholder'}", id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
+                    submit "#{_strings.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
                         script "queue_song($('#ecd-field').val());"
                     end
                 end
             end
-            div id: "developer-tools" do
+div id: "developer-tools" do
                 ibox do
                     type :warning
-                    block_button nil, t(_strings, "clear_local_storage"), id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
+                    block_button nil, "#{_strings.dig('clear_local_storage', 'en') || 'clear_local_storage'}", id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
                         script "localStorage.clear();"
                     end
-                    block_button nil, t(_strings, "clear_session_storage"), id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
+                    block_button nil, "#{_strings.dig('clear_session_storage', 'en') || 'clear_session_storage'}", id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
                         script "sessionStorage.clear();"
                     end
-                    title t(_strings, "developer_tools_title")
-                    block_button nil, t(_strings, "toggle_debug_mode"), id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
+                    title "#{_strings.dig('developer_tools_title', 'en') || 'developer_tools_title'}"
+                    block_button nil, "#{_strings.dig('toggle_debug_mode', 'en') || 'toggle_debug_mode'}", id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
                         script "toggle_debug();"
                     end
                     div id: "debug-div", style: "display: none;" do
                         # TODO: feature request to weaver to enable click on .panel-heading
                         accordion do
-                            tab t(_strings, "device_info_tab") do
+                            tab "#{_strings.dig('device_info_tab', 'en') || 'device_info_tab'}" do
                                 pre id: "device-info"
                             end
-                            tab t(_strings, "session_storage_tab") do
+                            tab "#{_strings.dig('session_storage_tab', 'en') || 'session_storage_tab'}" do
                                 pre id: "session-storage"
                             end
-                            tab t(_strings, "local_storage_tab") do
+                            tab "#{_strings.dig('local_storage_tab', 'en') || 'local_storage_tab'}" do
                                 pre id: "local-storage"
                             end
                         end
@@ -195,7 +181,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     div id: "footer" do
         div id: "button-container" do
-            block_button :qrcode, t(_strings, "scan_qr_code"), id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
+            block_button :qrcode, "#{_strings.dig('scan_qr_code', 'en') || 'scan_qr_code'}", id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
                 script "$('#scan-modal').modal('show'); scan_qr();"
             end
             normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
@@ -211,7 +197,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     #
     modal "scan-modal" do
         header {
-            h4 s(_strings, "scan_qr_code")
+            h4 "<span data-i18n=\"scan_qr_code\">#{_strings.dig('scan_qr_code', 'en') || 'scan_qr_code'}</span>"
         }
         body {
             div class: "camera-container" do
@@ -219,13 +205,13 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 end
                 div id: "selector-container", style: "display: none;" do
                     wform id: "camera_form" do
-                        dropdown "cameras", t(_strings, "select_camera"), [], id: "camera-selector"
+                        dropdown "cameras", "#{_strings.dig('select_camera', 'en') || 'select_camera'}", [], id: "camera-selector"
                     end
                 end
             end
         }
         footer do
-            block_button t(_strings, "close_button"), id: "scan-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "scan-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#scan-modal').modal('hide');"
             end
         end
@@ -233,29 +219,29 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "search-help-modal" do
         header {
-            h4 s(_strings, "search_help_title"), id: "search-help-modal-title"
+            h4 "<span data-i18n=\"search_help_title\">#{_strings.dig('search_help_title', 'en') || 'search_help_title'}</span>", id: "search-help-modal-title"
         }
         body {
             div id: "search-help-modal-body" do
                 code "artist:"
                 p do
-                    span s(_strings, "search_help_artist")
+                    span "<span data-i18n=\"search_help_artist\">#{_strings.dig('search_help_artist', 'en') || 'search_help_artist'}</span>"
                     code "artist:yoasobi"
                 end
                 code "genre:"
                 p do
-                    span s(_strings, "search_help_genre")
+                    span "<span data-i18n=\"search_help_genre\">#{_strings.dig('search_help_genre', 'en') || 'search_help_genre'}</span>"
                     code "genre:アニメ"
                 end
                 code "type:"
                 p do
-                    span s(_strings, "search_help_type")
+                    span "<span data-i18n=\"search_help_type\">#{_strings.dig('search_help_type', 'en') || 'search_help_type'}</span>"
                     code "type:vocaloid"
                 end
             end
         }
         footer do
-            block_button t(_strings, "close_button"), id: "search-help-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "search-help-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#search-help-modal').modal('hide');"
             end
         end
@@ -270,7 +256,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button t(_strings, "add_to_queue_button"), id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
+            block_button "#{_strings.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
                 script "queue_song($('#current-song-code').text())"
             end
             normal_button :heart, nil, style: "default", id: "favourite-button" do
@@ -281,11 +267,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "info-modal" do
         header {
-            h4 s(_strings, "info_modal_title"), id: "info-modal-title"
+            h4 "<span data-i18n=\"info_modal_title\">#{_strings.dig('info_modal_title', 'en') || 'info_modal_title'}</span>", id: "info-modal-title"
         }
         body {
             div id: "info-modal-body" do
-                h4 s(_strings, "session_status_heading")
+                h4 "<span data-i18n=\"session_status_heading\">#{_strings.dig('session_status_heading', 'en') || 'session_status_heading'}</span>"
                 p id: "connected" do
                 end
                 div id: "most-played" do
@@ -293,7 +279,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button t(_strings, "close_button"), id: "info-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "info-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#info-modal').modal('hide');"
             end
         end

--- a/source/index.weave
+++ b/source/index.weave
@@ -1,8 +1,28 @@
 # vim:ft=ruby
+require 'json'
+
+# Load all UI strings from the project root
+_strings = JSON.parse(File.read(File.join(__dir__, 'strings.json')))
+
+# Helper: returns the English text for a key (used as weaver string arguments)
+# and renders a <span data-i18n="key"> so JS can swap to Japanese at runtime.
+def s(strings, key)
+  en = strings.dig(key, 'en') || key
+  "<span data-i18n=\"#{key}\">#{en}</span>"
+end
+
+# Plain English text for arguments that weaver renders as HTML attributes
+# (e.g. tab names, button labels) — weaver wraps these itself so we use spans.
+# For truly plain-text-only contexts we fall back to the English string directly.
+def t(strings, key)
+  strings.dig(key, 'en') || key
+end
+
 empty_page "", "alesap.blankaex.reisen", theme: :dark do
     #
     # Imports
     #
+    request_js "js/i18n.js"
     request_js "js/utils.js"
     request_js "js/song.js"
     request_js "js/main.js"
@@ -22,11 +42,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     # Content
     #
     tabs do
-        tab "Search" do
-            h4 "Song search:"
+        tab t(_strings, "tab_search") do
+            h4 s(_strings, "song_search_heading")
             wform id: "song_search_form" do
-                textfield "search", nil, placeholder: "Type to start searching", id: "search-field"
-                submit "Search", :search do
+                textfield "search", nil, placeholder: t(_strings, "search_placeholder"), id: "search-field", "data-i18n-placeholder": "search_placeholder"
+                submit t(_strings, "search_button"), :search, id: "search-button", "data-i18n-value": "search_button" do
                     script "start_search();"
                 end
                 normal_button :stop, nil, id: "stop-playback", style: "danger", css_style: "display: none;" do
@@ -34,14 +54,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 end
             end
             small id: "search-help" do
-                a "Search help", href: "javascript:$('#search-help-modal').modal('show');;"
+                a s(_strings, "search_help_link"), href: "javascript:$('#search-help-modal').modal('show');;"
             end
             # wrap table in div to avoid conflicts with pagination element
             div do
                 table striped: true, id: "song-table", style: "display: none;" do
                     thead id: "song-table-head" do
-                        th { text "Title" }
-                        th { text "Artist" }
+                        th { text s(_strings, "column_title") }
+                        th { text s(_strings, "column_artist") }
                     end
                     tbody id: "song-table-body" do
                     end
@@ -49,7 +69,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "empty-search", style: "display: none;" do
                 jumbotron do
-                  span "Nothing to see here 😗"
+                  span s(_strings, "empty_search")
                 end
             end
             div id: "loader-div" do
@@ -58,23 +78,23 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "History" do
+        tab t(_strings, "tab_history") do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-history" do
                 jumbotron do
-                    p "No songs in history 🥺"
-                    span  "Queue a song to get started"
+                    p s(_strings, "empty_history_title")
+                    span s(_strings, "empty_history_subtitle")
                 end
             end
             div id: "history", style: "display: none;" do
-                block_button :magic, "I'm feeling lucky", id: "random-history", style: "none" do
+                block_button :magic, t(_strings, "feeling_lucky"), id: "random-history", style: "none" do
                     script "queue_random('history');"
                 end
                 table striped: true, id: "history-table" do
                     thead id: "history-table-head" do
-                        th { text "Title" }
-                        th { text "Artist" }
-                        th { text "Last Played" }
+                        th { text s(_strings, "column_title") }
+                        th { text s(_strings, "column_artist") }
+                        th { text s(_strings, "column_last_played") }
                     end
                     tbody id: "history-table-body" do
                     end
@@ -82,22 +102,22 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "Favourites" do
+        tab t(_strings, "tab_favourites") do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-favourites" do
                 jumbotron do
-                    p "No songs in favourites 🥺"
-                    span  "Favourite a song to get started"
+                    p s(_strings, "empty_favourites_title")
+                    span s(_strings, "empty_favourites_subtitle")
                 end
             end
             div id: "favourites", style: "display: none;" do
-                block_button :magic, "I'm feeling lucky", id: "random-favourite", style: "none" do
+                block_button :magic, t(_strings, "feeling_lucky"), id: "random-favourite", style: "none" do
                     script "queue_random('favourites');"
                 end
                 table striped: true, id: "favourites-table" do
                     thead id: "favourites-table-head" do
-                        th { text "Title" }
-                        th { text "Artist" }
+                        th { text s(_strings, "column_title") }
+                        th { text s(_strings, "column_artist") }
                     end
                     tbody id: "favourites-table-body" do
                     end
@@ -105,25 +125,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "Advanced" do
+        tab t(_strings, "tab_advanced") do
             ibox do
                 type :panel
-                title "Settings"
+                title t(_strings, "settings_title")
                 div id: "settings" do
-                    h4 "Nickname:"
+                    h4 s(_strings, "nickname_heading")
                     wform id: "nickname_form" do
                         textfield "nickname", nil, id: "nickname-field"
-                        submit "Set nickname", :check do
+                        submit t(_strings, "set_nickname_button"), :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
                             script "set_nickname(false);"
                         end
                     end
-                    h4 "Options:"
+                    h4 s(_strings, "options_heading")
                     wform id: "developer_mode_form" do
-                        checkbox "developer-mode", "Enable Developer Tools"
+                        checkbox "developer-mode", t(_strings, "enable_developer_tools"), id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
+                        checkbox "japanese-mode", t(_strings, "enable_japanese"), id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
                     end
-                    h4 "Info:"
+                    h4 s(_strings, "info_heading")
                     div do
-                        block_button nil, "Show Info", id: "show-info" do
+                        block_button nil, t(_strings, "show_info_button"), id: "show-info", "data-i18n-btn": "show_info_button" do
                             script "show_info();"
                         end
                     end
@@ -131,11 +152,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             ibox do
                 type :panel
-                title "Queue song by code"
+                title t(_strings, "queue_song_by_code")
                 # TODO: weaver breaks when form ids contain - (changes function name)
                 wform id: "queue_code_form" do
-                    textfield "ecd", nil, placeholder: "Song code", id: "ecd-field"
-                    submit "Add to queue", :play do
+                    textfield "ecd", nil, placeholder: t(_strings, "song_code_placeholder"), id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
+                    submit t(_strings, "add_to_queue_button"), :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
                         script "queue_song($('#ecd-field').val());"
                     end
                 end
@@ -143,26 +164,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             div id: "developer-tools" do
                 ibox do
                     type :warning
-                    block_button nil, "Clear localStorage", style: "warning" do
+                    block_button nil, t(_strings, "clear_local_storage"), id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
                         script "localStorage.clear();"
                     end
-                    block_button nil, "Clear sessionStorage", style: "warning" do
+                    block_button nil, t(_strings, "clear_session_storage"), id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
                         script "sessionStorage.clear();"
                     end
-                    title "Developer Tools"
-                    block_button nil, "Toggle Debug Mode", style: "warning" do
+                    title t(_strings, "developer_tools_title")
+                    block_button nil, t(_strings, "toggle_debug_mode"), id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
                         script "toggle_debug();"
                     end
                     div id: "debug-div", style: "display: none;" do
                         # TODO: feature request to weaver to enable click on .panel-heading
                         accordion do
-                            tab "Device Info" do
+                            tab t(_strings, "device_info_tab") do
                                 pre id: "device-info"
                             end
-                            tab "sessionStorage" do
+                            tab t(_strings, "session_storage_tab") do
                                 pre id: "session-storage"
                             end
-                            tab "localStorage" do
+                            tab t(_strings, "local_storage_tab") do
                                 pre id: "local-storage"
                             end
                         end
@@ -174,7 +195,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     div id: "footer" do
         div id: "button-container" do
-            block_button :qrcode, "Scan QR Code", id: "scan-qr" do
+            block_button :qrcode, t(_strings, "scan_qr_code"), id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
                 script "$('#scan-modal').modal('show'); scan_qr();"
             end
             normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
@@ -183,14 +204,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
         end
     end
 
-    small "Created by <a href='https://github.com/davidsiaw/alesap-server'>astrobunny</a> and <a href='https://github.com/blankaex/alesap'>Blankaex</a>"
+    small _strings.dig('created_by', 'en'), id: "created-by", "data-i18n-html": "created_by"
 
     #
     # Modals
     #
     modal "scan-modal" do
         header {
-            h4 "Scan QR Code"
+            h4 s(_strings, "scan_qr_code")
         }
         body {
             div class: "camera-container" do
@@ -198,13 +219,13 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 end
                 div id: "selector-container", style: "display: none;" do
                     wform id: "camera_form" do
-                        dropdown "cameras", "Select Camera", [], id: "camera-selector"
+                        dropdown "cameras", t(_strings, "select_camera"), [], id: "camera-selector"
                     end
                 end
             end
         }
         footer do
-            block_button "Close" do
+            block_button t(_strings, "close_button"), id: "scan-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#scan-modal').modal('hide');"
             end
         end
@@ -212,29 +233,29 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "search-help-modal" do
         header {
-            h4 "Search Help", id: "search-help-modal-title"
+            h4 s(_strings, "search_help_title"), id: "search-help-modal-title"
         }
         body {
             div id: "search-help-modal-body" do
                 code "artist:"
                 p do
-                    text "Filter by artist, e.g. "
+                    span s(_strings, "search_help_artist")
                     code "artist:yoasobi"
                 end
                 code "genre:"
                 p do
-                    text "Filter by genre, e.g. "
+                    span s(_strings, "search_help_genre")
                     code "genre:アニメ"
                 end
                 code "type:"
                 p do
-                    text "Filter by content type, e.g. "
+                    span s(_strings, "search_help_type")
                     code "type:vocaloid"
                 end
             end
         }
         footer do
-            block_button "Close" do
+            block_button t(_strings, "close_button"), id: "search-help-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#search-help-modal').modal('hide');"
             end
         end
@@ -249,7 +270,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button "Add to queue", id: "add-to-queue", style: "none" do
+            block_button t(_strings, "add_to_queue_button"), id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
                 script "queue_song($('#current-song-code').text())"
             end
             normal_button :heart, nil, style: "default", id: "favourite-button" do
@@ -260,11 +281,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "info-modal" do
         header {
-            h4 "Info", id: "info-modal-title"
+            h4 s(_strings, "info_modal_title"), id: "info-modal-title"
         }
         body {
             div id: "info-modal-body" do
-                h4 "Session Status:"
+                h4 s(_strings, "session_status_heading")
                 p id: "connected" do
                 end
                 div id: "most-played" do
@@ -272,7 +293,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button "Close" do
+            block_button t(_strings, "close_button"), id: "info-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#info-modal').modal('hide');"
             end
         end

--- a/source/index.weave
+++ b/source/index.weave
@@ -2,7 +2,11 @@
 require 'json'
 
 # Load all UI strings from the project root
-_strings = JSON.parse(File.read(File.join(__dir__, 'strings.json')))
+STRINGS = JSON.parse(File.read(File.join(__dir__, 'strings.json')))
+
+raw_page "strings.json", "strings.json" do
+    text File.read("source/strings.json")
+end
 
 empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
@@ -32,11 +36,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     # Content
     #
     tabs do
-        tab "#{_strings.dig('tab_search', 'en') || 'tab_search'}" do
-            h4 "<span data-i18n=\"song_search_heading\">#{_strings.dig('song_search_heading', 'en') || 'song_search_heading'}</span>"
+        tab "#{STRINGS.dig('tab_search', 'en') || 'tab_search'}" do
+            h4 "<span data-i18n=\"song_search_heading\">#{STRINGS.dig('song_search_heading', 'en') || 'song_search_heading'}</span>"
             wform id: "song_search_form" do
-                textfield "search", nil, placeholder: "#{_strings.dig('search_placeholder', 'en') || 'search_placeholder'}", id: "search-field", "data-i18n-placeholder": "search_placeholder"
-                submit "#{_strings.dig('search_button', 'en') || 'search_button'}", :search, id: "search-button", "data-i18n-value": "search_button" do
+                textfield "search", nil, placeholder: "#{STRINGS.dig('search_placeholder', 'en') || 'search_placeholder'}", id: "search-field", "data-i18n-placeholder": "search_placeholder"
+                submit "#{STRINGS.dig('search_button', 'en') || 'search_button'}", :search, id: "search-button", "data-i18n-value": "search_button" do
                     script "start_search();"
                 end
                 span class: "stop-playback", css_style: "display: none;" do
@@ -52,14 +56,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 ], value: "all"
             end
             small id: "search-help" do
-                a "<span data-i18n=\"search_help_link\">#{_strings.dig('search_help_link', 'en') || 'search_help_link'}</span>", href: "javascript:$('#search-help-modal').modal('show');;"
+                a "<span data-i18n=\"search_help_link\">#{STRINGS.dig('search_help_link', 'en') || 'search_help_link'}</span>", href: "javascript:$('#search-help-modal').modal('show');;"
             end
             # wrap table in div to avoid conflicts with pagination element
             div do
                 table striped: true, id: "song-table", style: "display: none;" do
                     thead id: "song-table-head" do
-                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
-                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
+                        th { text "<span data-i18n=\"column_title\">#{STRINGS.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{STRINGS.dig('column_artist', 'en') || 'column_artist'}</span>" }
                     end
                     tbody id: "song-table-body" do
                     end
@@ -67,7 +71,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "empty-search", style: "display: none;" do
                 jumbotron do
-                  span "<span data-i18n=\"empty_search\">#{_strings.dig('empty_search', 'en') || 'empty_search'}</span>"
+                  span "<span data-i18n=\"empty_search\">#{STRINGS.dig('empty_search', 'en') || 'empty_search'}</span>"
                 end
             end
             div id: "loader-div" do
@@ -76,12 +80,12 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "#{_strings.dig('tab_history', 'en') || 'tab_history'}" do
+        tab "#{STRINGS.dig('tab_history', 'en') || 'tab_history'}" do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-history" do
                 jumbotron do
-                    p "<span data-i18n=\"empty_history_title\">#{_strings.dig('empty_history_title', 'en') || 'empty_history_title'}</span>"
-                    span "<span data-i18n=\"empty_history_subtitle\">#{_strings.dig('empty_history_subtitle', 'en') || 'empty_history_subtitle'}</span>"
+                    p "<span data-i18n=\"empty_history_title\">#{STRINGS.dig('empty_history_title', 'en') || 'empty_history_title'}</span>"
+                    span "<span data-i18n=\"empty_history_subtitle\">#{STRINGS.dig('empty_history_subtitle', 'en') || 'empty_history_subtitle'}</span>"
                 end
             end
             div id: "history", style: "display: none;" do
@@ -94,14 +98,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
-                block_button :magic, "#{_strings.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-history", style: "none" do
+                block_button :magic, "#{STRINGS.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-history", style: "none" do
                     script "queue_random('history');"
                 end
                 table striped: true, id: "history-table" do
                     thead id: "history-table-head" do
-                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
-                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
-                        th { text "<span data-i18n=\"column_last_played\">#{_strings.dig('column_last_played', 'en') || 'column_last_played'}</span>" }
+                        th { text "<span data-i18n=\"column_title\">#{STRINGS.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{STRINGS.dig('column_artist', 'en') || 'column_artist'}</span>" }
+                        th { text "<span data-i18n=\"column_last_played\">#{STRINGS.dig('column_last_played', 'en') || 'column_last_played'}</span>" }
                     end
                     tbody id: "history-table-body" do
                     end
@@ -109,12 +113,12 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "#{_strings.dig('tab_favourites', 'en') || 'tab_favourites'}" do
+        tab "#{STRINGS.dig('tab_favourites', 'en') || 'tab_favourites'}" do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-favourites" do
                 jumbotron do
-                    p "<span data-i18n=\"empty_favourites_title\">#{_strings.dig('empty_favourites_title', 'en') || 'empty_favourites_title'}</span>"
-                    span "<span data-i18n=\"empty_favourites_subtitle\">#{_strings.dig('empty_favourites_subtitle', 'en') || 'empty_favourites_subtitle'}</span>"
+                    p "<span data-i18n=\"empty_favourites_title\">#{STRINGS.dig('empty_favourites_title', 'en') || 'empty_favourites_title'}</span>"
+                    span "<span data-i18n=\"empty_favourites_subtitle\">#{STRINGS.dig('empty_favourites_subtitle', 'en') || 'empty_favourites_subtitle'}</span>"
                 end
             end
             div id: "favourites", style: "display: none;" do
@@ -127,13 +131,13 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
-                block_button :magic, "#{_strings.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-favourite", style: "none" do
+                block_button :magic, "#{STRINGS.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-favourite", style: "none" do
                     script "queue_random('favourites');"
                 end
                 table striped: true, id: "favourites-table" do
                     thead id: "favourites-table-head" do
-                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
-                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
+                        th { text "<span data-i18n=\"column_title\">#{STRINGS.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{STRINGS.dig('column_artist', 'en') || 'column_artist'}</span>" }
                     end
                     tbody id: "favourites-table-body" do
                     end
@@ -141,26 +145,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "#{_strings.dig('tab_advanced', 'en') || 'tab_advanced'}" do
+        tab "#{STRINGS.dig('tab_advanced', 'en') || 'tab_advanced'}" do
             ibox do
                 type :panel
-                title "#{_strings.dig('settings_title', 'en') || 'settings_title'}"
+                title "#{STRINGS.dig('settings_title', 'en') || 'settings_title'}"
                 div id: "settings" do
-                    h4 "<span data-i18n=\"nickname_heading\">#{_strings.dig('nickname_heading', 'en') || 'nickname_heading'}</span>"
+                    h4 "<span data-i18n=\"nickname_heading\">#{STRINGS.dig('nickname_heading', 'en') || 'nickname_heading'}</span>"
                     wform id: "nickname_form" do
                         textfield "nickname", nil, id: "nickname-field"
-                        submit "#{_strings.dig('set_nickname_button', 'en') || 'set_nickname_button'}", :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
+                        submit "#{STRINGS.dig('set_nickname_button', 'en') || 'set_nickname_button'}", :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
                             script "set_nickname(false);"
                         end
                     end
-                    h4 "<span data-i18n=\"options_heading\">#{_strings.dig('options_heading', 'en') || 'options_heading'}</span>"
+                    h4 "<span data-i18n=\"options_heading\">#{STRINGS.dig('options_heading', 'en') || 'options_heading'}</span>"
                     wform id: "developer_mode_form" do
-                        checkbox "developer-mode", "#{_strings.dig('enable_developer_tools', 'en') || 'enable_developer_tools'}", id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
-                        checkbox "japanese-mode", "#{_strings.dig('enable_japanese', 'en') || 'enable_japanese'}", id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
+                        checkbox "developer-mode", "#{STRINGS.dig('enable_developer_tools', 'en') || 'enable_developer_tools'}", id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
+                        checkbox "japanese-mode", "#{STRINGS.dig('enable_japanese', 'en') || 'enable_japanese'}", id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
                     end
-                    h4 "<span data-i18n=\"info_heading\">#{_strings.dig('info_heading', 'en') || 'info_heading'}</span>"
+                    h4 "<span data-i18n=\"info_heading\">#{STRINGS.dig('info_heading', 'en') || 'info_heading'}</span>"
                     div do
-                        block_button nil, "#{_strings.dig('show_info_button', 'en') || 'show_info_button'}", id: "show-info", "data-i18n-btn": "show_info_button" do
+                        block_button nil, "#{STRINGS.dig('show_info_button', 'en') || 'show_info_button'}", id: "show-info", "data-i18n-btn": "show_info_button" do
                             script "show_info();"
                         end
                     end
@@ -168,11 +172,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             ibox do
                 type :panel
-                title "#{_strings.dig('queue_song_by_code', 'en') || 'queue_song_by_code'}"
+                title "#{STRINGS.dig('queue_song_by_code', 'en') || 'queue_song_by_code'}"
                 # TODO: weaver breaks when form ids contain - (changes function name)
                 wform id: "queue_code_form" do
-                    textfield "ecd", nil, placeholder: "#{_strings.dig('song_code_placeholder', 'en') || 'song_code_placeholder'}", id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
-                    submit "#{_strings.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
+                    textfield "ecd", nil, placeholder: "#{STRINGS.dig('song_code_placeholder', 'en') || 'song_code_placeholder'}", id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
+                    submit "#{STRINGS.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
                         script "queue_song($('#ecd-field').val());"
                     end
                 end
@@ -180,26 +184,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 div id: "developer-tools" do
                 ibox do
                     type :warning
-                    block_button nil, "#{_strings.dig('clear_local_storage', 'en') || 'clear_local_storage'}", id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
+                    block_button nil, "#{STRINGS.dig('clear_local_storage', 'en') || 'clear_local_storage'}", id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
                         script "localStorage.clear();"
                     end
-                    block_button nil, "#{_strings.dig('clear_session_storage', 'en') || 'clear_session_storage'}", id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
+                    block_button nil, "#{STRINGS.dig('clear_session_storage', 'en') || 'clear_session_storage'}", id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
                         script "sessionStorage.clear();"
                     end
-                    title "#{_strings.dig('developer_tools_title', 'en') || 'developer_tools_title'}"
-                    block_button nil, "#{_strings.dig('toggle_debug_mode', 'en') || 'toggle_debug_mode'}", id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
+                    title "#{STRINGS.dig('developer_tools_title', 'en') || 'developer_tools_title'}"
+                    block_button nil, "#{STRINGS.dig('toggle_debug_mode', 'en') || 'toggle_debug_mode'}", id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
                         script "toggle_debug();"
                     end
                     div id: "debug-div", style: "display: none;" do
                         # TODO: feature request to weaver to enable click on .panel-heading
                         accordion do
-                            tab "#{_strings.dig('device_info_tab', 'en') || 'device_info_tab'}" do
+                            tab "#{STRINGS.dig('device_info_tab', 'en') || 'device_info_tab'}" do
                                 pre id: "device-info"
                             end
-                            tab "#{_strings.dig('session_storage_tab', 'en') || 'session_storage_tab'}" do
+                            tab "#{STRINGS.dig('session_storage_tab', 'en') || 'session_storage_tab'}" do
                                 pre id: "session-storage"
                             end
-                            tab "#{_strings.dig('local_storage_tab', 'en') || 'local_storage_tab'}" do
+                            tab "#{STRINGS.dig('local_storage_tab', 'en') || 'local_storage_tab'}" do
                                 pre id: "local-storage"
                             end
                         end
@@ -217,7 +221,7 @@ div id: "developer-tools" do
             script "update_status(false);"
     div id: "footer" do
         div id: "button-container" do
-            block_button :qrcode, "#{_strings.dig('scan_qr_code', 'en') || 'scan_qr_code'}", id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
+            block_button :qrcode, "#{STRINGS.dig('scan_qr_code', 'en') || 'scan_qr_code'}", id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
                 script "$('#scan-modal').modal('show'); scan_qr();"
             end
             normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
@@ -226,14 +230,14 @@ div id: "developer-tools" do
         end
     end
 
-    small _strings.dig('created_by', 'en'), id: "created-by", "data-i18n-html": "created_by"
+    small STRINGS.dig('created_by', 'en'), id: "created-by", "data-i18n-html": "created_by"
 
     #
     # Modals
     #
     modal "scan-modal" do
         header {
-            h4 "<span data-i18n=\"scan_qr_code\">#{_strings.dig('scan_qr_code', 'en') || 'scan_qr_code'}</span>"
+            h4 "<span data-i18n=\"scan_qr_code\">#{STRINGS.dig('scan_qr_code', 'en') || 'scan_qr_code'}</span>"
         }
         body {
             div class: "camera-container" do
@@ -241,13 +245,13 @@ div id: "developer-tools" do
                 end
                 div id: "selector-container", style: "display: none;" do
                     wform id: "camera_form" do
-                        dropdown "cameras", "#{_strings.dig('select_camera', 'en') || 'select_camera'}", [], id: "camera-selector"
+                        dropdown "cameras", "#{STRINGS.dig('select_camera', 'en') || 'select_camera'}", [], id: "camera-selector"
                     end
                 end
             end
         }
         footer do
-            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "scan-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{STRINGS.dig('close_button', 'en') || 'close_button'}", id: "scan-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#scan-modal').modal('hide');"
             end
         end
@@ -255,29 +259,29 @@ div id: "developer-tools" do
 
     modal "search-help-modal" do
         header {
-            h4 "<span data-i18n=\"search_help_title\">#{_strings.dig('search_help_title', 'en') || 'search_help_title'}</span>", id: "search-help-modal-title"
+            h4 "<span data-i18n=\"search_help_title\">#{STRINGS.dig('search_help_title', 'en') || 'search_help_title'}</span>", id: "search-help-modal-title"
         }
         body {
             div id: "search-help-modal-body" do
                 code "artist:"
                 p do
-                    span "<span data-i18n=\"search_help_artist\">#{_strings.dig('search_help_artist', 'en') || 'search_help_artist'}</span>"
+                    span "<span data-i18n=\"search_help_artist\">#{STRINGS.dig('search_help_artist', 'en') || 'search_help_artist'}</span>"
                     code "artist:yoasobi"
                 end
                 code "genre:"
                 p do
-                    span "<span data-i18n=\"search_help_genre\">#{_strings.dig('search_help_genre', 'en') || 'search_help_genre'}</span>"
+                    span "<span data-i18n=\"search_help_genre\">#{STRINGS.dig('search_help_genre', 'en') || 'search_help_genre'}</span>"
                     code "genre:アニメ"
                 end
                 code "type:"
                 p do
-                    span "<span data-i18n=\"search_help_type\">#{_strings.dig('search_help_type', 'en') || 'search_help_type'}</span>"
+                    span "<span data-i18n=\"search_help_type\">#{STRINGS.dig('search_help_type', 'en') || 'search_help_type'}</span>"
                     code "type:vocaloid"
                 end
             end
         }
         footer do
-            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "search-help-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{STRINGS.dig('close_button', 'en') || 'close_button'}", id: "search-help-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#search-help-modal').modal('hide');"
             end
         end
@@ -292,7 +296,7 @@ div id: "developer-tools" do
             end
         }
         footer do
-            block_button "#{_strings.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
+            block_button "#{STRINGS.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
                 script "queue_song($('#current-song-code').text())"
             end
             normal_button :heart, nil, style: "default", id: "favourite-button" do
@@ -303,11 +307,11 @@ div id: "developer-tools" do
 
     modal "info-modal" do
         header {
-            h4 "<span data-i18n=\"info_modal_title\">#{_strings.dig('info_modal_title', 'en') || 'info_modal_title'}</span>", id: "info-modal-title"
+            h4 "<span data-i18n=\"info_modal_title\">#{STRINGS.dig('info_modal_title', 'en') || 'info_modal_title'}</span>", id: "info-modal-title"
         }
         body {
             div id: "info-modal-body" do
-                h4 "<span data-i18n=\"session_status_heading\">#{_strings.dig('session_status_heading', 'en') || 'session_status_heading'}</span>"
+                h4 "<span data-i18n=\"session_status_heading\">#{STRINGS.dig('session_status_heading', 'en') || 'session_status_heading'}</span>"
                 p id: "connected" do
                 end
                 div id: "most-played" do
@@ -315,7 +319,7 @@ div id: "developer-tools" do
             end
         }
         footer do
-            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "info-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{STRINGS.dig('close_button', 'en') || 'close_button'}", id: "info-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#info-modal').modal('hide');"
             end
         end

--- a/source/index.weave
+++ b/source/index.weave
@@ -90,7 +90,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "history", style: "display: none;" do
                 div class: "button-container" do
-                    block_button :magic, "I'm feeling lucky", id: "random-history", style: "none" do
+                    block_button :magic, "#{STRINGS.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-history", style: "none" do
                         script "queue_random('history');"
                     end
                     span class: "stop-playback", css_style: "display: none;" do
@@ -98,8 +98,6 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
-                block_button :magic, "#{STRINGS.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-history", style: "none" do
-                    script "queue_random('history');"
                 end
                 table striped: true, id: "history-table" do
                     thead id: "history-table-head" do
@@ -123,7 +121,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "favourites", style: "display: none;" do
                 div class: "button-container" do
-                    block_button :magic, "I'm feeling lucky", id: "random-favourite", style: "none" do
+                    block_button :magic, "#{STRINGS.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-favourite", style: "none" do
                         script "queue_random('favourites');"
                     end
                     span class: "stop-playback", css_style: "display: none;" do
@@ -131,8 +129,6 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
-                block_button :magic, "#{STRINGS.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-favourite", style: "none" do
-                    script "queue_random('favourites');"
                 end
                 table striped: true, id: "favourites-table" do
                     thead id: "favourites-table-head" do
@@ -213,12 +209,6 @@ div id: "developer-tools" do
         end
     end
 
-    div id: "footer", class: "panel-body button-container" do
-        block_button :qrcode, "Scan QR Code", id: "scan-qr" do
-            script "$('#scan-modal').modal('show'); scan_qr();"
-        end
-        normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
-            script "update_status(false);"
     div id: "footer" do
         div id: "button-container" do
             block_button :qrcode, "#{STRINGS.dig('scan_qr_code', 'en') || 'scan_qr_code'}", id: "scan-qr", "data-i18n-btn": "scan_qr_code" do

--- a/source/index.weave
+++ b/source/index.weave
@@ -4,20 +4,6 @@ require 'json'
 # Load all UI strings from the project root
 _strings = JSON.parse(File.read(File.join(__dir__, 'strings.json')))
 
-# Helper: returns the English text for a key (used as weaver string arguments)
-# and renders a <span data-i18n="key"> so JS can swap to Japanese at runtime.
-def s(strings, key)
-  en = strings.dig(key, 'en') || key
-  "<span data-i18n=\"#{key}\">#{en}</span>"
-end
-
-# Plain English text for arguments that weaver renders as HTML attributes
-# (e.g. tab names, button labels) — weaver wraps these itself so we use spans.
-# For truly plain-text-only contexts we fall back to the English string directly.
-def t(strings, key)
-  strings.dig(key, 'en') || key
-end
-
 empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     ## HACK IOS ZOOM
@@ -46,11 +32,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     # Content
     #
     tabs do
-        tab t(_strings, "tab_search") do
-            h4 s(_strings, "song_search_heading")
+        tab "#{_strings.dig('tab_search', 'en') || 'tab_search'}" do
+            h4 "<span data-i18n=\"song_search_heading\">#{_strings.dig('song_search_heading', 'en') || 'song_search_heading'}</span>"
             wform id: "song_search_form" do
-                textfield "search", nil, placeholder: t(_strings, "search_placeholder"), id: "search-field", "data-i18n-placeholder": "search_placeholder"
-                submit t(_strings, "search_button"), :search, id: "search-button", "data-i18n-value": "search_button" do
+                textfield "search", nil, placeholder: "#{_strings.dig('search_placeholder', 'en') || 'search_placeholder'}", id: "search-field", "data-i18n-placeholder": "search_placeholder"
+                submit "#{_strings.dig('search_button', 'en') || 'search_button'}", :search, id: "search-button", "data-i18n-value": "search_button" do
                     script "start_search();"
                 end
                 span class: "stop-playback", css_style: "display: none;" do
@@ -66,14 +52,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 ], value: "all"
             end
             small id: "search-help" do
-                a s(_strings, "search_help_link"), href: "javascript:$('#search-help-modal').modal('show');;"
+                a "<span data-i18n=\"search_help_link\">#{_strings.dig('search_help_link', 'en') || 'search_help_link'}</span>", href: "javascript:$('#search-help-modal').modal('show');;"
             end
             # wrap table in div to avoid conflicts with pagination element
             div do
                 table striped: true, id: "song-table", style: "display: none;" do
                     thead id: "song-table-head" do
-                        th { text s(_strings, "column_title") }
-                        th { text s(_strings, "column_artist") }
+                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
                     end
                     tbody id: "song-table-body" do
                     end
@@ -81,7 +67,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "empty-search", style: "display: none;" do
                 jumbotron do
-                  span s(_strings, "empty_search")
+                  span "<span data-i18n=\"empty_search\">#{_strings.dig('empty_search', 'en') || 'empty_search'}</span>"
                 end
             end
             div id: "loader-div" do
@@ -90,12 +76,12 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab t(_strings, "tab_history") do
+        tab "#{_strings.dig('tab_history', 'en') || 'tab_history'}" do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-history" do
                 jumbotron do
-                    p s(_strings, "empty_history_title")
-                    span s(_strings, "empty_history_subtitle")
+                    p "<span data-i18n=\"empty_history_title\">#{_strings.dig('empty_history_title', 'en') || 'empty_history_title'}</span>"
+                    span "<span data-i18n=\"empty_history_subtitle\">#{_strings.dig('empty_history_subtitle', 'en') || 'empty_history_subtitle'}</span>"
                 end
             end
             div id: "history", style: "display: none;" do
@@ -108,14 +94,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
-                block_button :magic, t(_strings, "feeling_lucky"), id: "random-history", style: "none" do
+                block_button :magic, "#{_strings.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-history", style: "none" do
                     script "queue_random('history');"
                 end
                 table striped: true, id: "history-table" do
                     thead id: "history-table-head" do
-                        th { text s(_strings, "column_title") }
-                        th { text s(_strings, "column_artist") }
-                        th { text s(_strings, "column_last_played") }
+                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
+                        th { text "<span data-i18n=\"column_last_played\">#{_strings.dig('column_last_played', 'en') || 'column_last_played'}</span>" }
                     end
                     tbody id: "history-table-body" do
                     end
@@ -123,12 +109,12 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab t(_strings, "tab_favourites") do
+        tab "#{_strings.dig('tab_favourites', 'en') || 'tab_favourites'}" do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-favourites" do
                 jumbotron do
-                    p s(_strings, "empty_favourites_title")
-                    span s(_strings, "empty_favourites_subtitle")
+                    p "<span data-i18n=\"empty_favourites_title\">#{_strings.dig('empty_favourites_title', 'en') || 'empty_favourites_title'}</span>"
+                    span "<span data-i18n=\"empty_favourites_subtitle\">#{_strings.dig('empty_favourites_subtitle', 'en') || 'empty_favourites_subtitle'}</span>"
                 end
             end
             div id: "favourites", style: "display: none;" do
@@ -141,13 +127,13 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
-                block_button :magic, t(_strings, "feeling_lucky"), id: "random-favourite", style: "none" do
+                block_button :magic, "#{_strings.dig('feeling_lucky', 'en') || 'feeling_lucky'}", id: "random-favourite", style: "none" do
                     script "queue_random('favourites');"
                 end
                 table striped: true, id: "favourites-table" do
                     thead id: "favourites-table-head" do
-                        th { text s(_strings, "column_title") }
-                        th { text s(_strings, "column_artist") }
+                        th { text "<span data-i18n=\"column_title\">#{_strings.dig('column_title', 'en') || 'column_title'}</span>" }
+                        th { text "<span data-i18n=\"column_artist\">#{_strings.dig('column_artist', 'en') || 'column_artist'}</span>" }
                     end
                     tbody id: "favourites-table-body" do
                     end
@@ -155,26 +141,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab t(_strings, "tab_advanced") do
+        tab "#{_strings.dig('tab_advanced', 'en') || 'tab_advanced'}" do
             ibox do
                 type :panel
-                title t(_strings, "settings_title")
+                title "#{_strings.dig('settings_title', 'en') || 'settings_title'}"
                 div id: "settings" do
-                    h4 s(_strings, "nickname_heading")
+                    h4 "<span data-i18n=\"nickname_heading\">#{_strings.dig('nickname_heading', 'en') || 'nickname_heading'}</span>"
                     wform id: "nickname_form" do
                         textfield "nickname", nil, id: "nickname-field"
-                        submit t(_strings, "set_nickname_button"), :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
+                        submit "#{_strings.dig('set_nickname_button', 'en') || 'set_nickname_button'}", :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
                             script "set_nickname(false);"
                         end
                     end
-                    h4 s(_strings, "options_heading")
+                    h4 "<span data-i18n=\"options_heading\">#{_strings.dig('options_heading', 'en') || 'options_heading'}</span>"
                     wform id: "developer_mode_form" do
-                        checkbox "developer-mode", t(_strings, "enable_developer_tools"), id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
-                        checkbox "japanese-mode", t(_strings, "enable_japanese"), id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
+                        checkbox "developer-mode", "#{_strings.dig('enable_developer_tools', 'en') || 'enable_developer_tools'}", id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
+                        checkbox "japanese-mode", "#{_strings.dig('enable_japanese', 'en') || 'enable_japanese'}", id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
                     end
-                    h4 s(_strings, "info_heading")
+                    h4 "<span data-i18n=\"info_heading\">#{_strings.dig('info_heading', 'en') || 'info_heading'}</span>"
                     div do
-                        block_button nil, t(_strings, "show_info_button"), id: "show-info", "data-i18n-btn": "show_info_button" do
+                        block_button nil, "#{_strings.dig('show_info_button', 'en') || 'show_info_button'}", id: "show-info", "data-i18n-btn": "show_info_button" do
                             script "show_info();"
                         end
                     end
@@ -182,38 +168,38 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             ibox do
                 type :panel
-                title t(_strings, "queue_song_by_code")
+                title "#{_strings.dig('queue_song_by_code', 'en') || 'queue_song_by_code'}"
                 # TODO: weaver breaks when form ids contain - (changes function name)
                 wform id: "queue_code_form" do
-                    textfield "ecd", nil, placeholder: t(_strings, "song_code_placeholder"), id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
-                    submit t(_strings, "add_to_queue_button"), :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
+                    textfield "ecd", nil, placeholder: "#{_strings.dig('song_code_placeholder', 'en') || 'song_code_placeholder'}", id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
+                    submit "#{_strings.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
                         script "queue_song($('#ecd-field').val());"
                     end
                 end
             end
-            div id: "developer-tools" do
+div id: "developer-tools" do
                 ibox do
                     type :warning
-                    block_button nil, t(_strings, "clear_local_storage"), id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
+                    block_button nil, "#{_strings.dig('clear_local_storage', 'en') || 'clear_local_storage'}", id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
                         script "localStorage.clear();"
                     end
-                    block_button nil, t(_strings, "clear_session_storage"), id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
+                    block_button nil, "#{_strings.dig('clear_session_storage', 'en') || 'clear_session_storage'}", id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
                         script "sessionStorage.clear();"
                     end
-                    title t(_strings, "developer_tools_title")
-                    block_button nil, t(_strings, "toggle_debug_mode"), id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
+                    title "#{_strings.dig('developer_tools_title', 'en') || 'developer_tools_title'}"
+                    block_button nil, "#{_strings.dig('toggle_debug_mode', 'en') || 'toggle_debug_mode'}", id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
                         script "toggle_debug();"
                     end
                     div id: "debug-div", style: "display: none;" do
                         # TODO: feature request to weaver to enable click on .panel-heading
                         accordion do
-                            tab t(_strings, "device_info_tab") do
+                            tab "#{_strings.dig('device_info_tab', 'en') || 'device_info_tab'}" do
                                 pre id: "device-info"
                             end
-                            tab t(_strings, "session_storage_tab") do
+                            tab "#{_strings.dig('session_storage_tab', 'en') || 'session_storage_tab'}" do
                                 pre id: "session-storage"
                             end
-                            tab t(_strings, "local_storage_tab") do
+                            tab "#{_strings.dig('local_storage_tab', 'en') || 'local_storage_tab'}" do
                                 pre id: "local-storage"
                             end
                         end
@@ -231,7 +217,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             script "update_status(false);"
     div id: "footer" do
         div id: "button-container" do
-            block_button :qrcode, t(_strings, "scan_qr_code"), id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
+            block_button :qrcode, "#{_strings.dig('scan_qr_code', 'en') || 'scan_qr_code'}", id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
                 script "$('#scan-modal').modal('show'); scan_qr();"
             end
             normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
@@ -247,7 +233,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     #
     modal "scan-modal" do
         header {
-            h4 s(_strings, "scan_qr_code")
+            h4 "<span data-i18n=\"scan_qr_code\">#{_strings.dig('scan_qr_code', 'en') || 'scan_qr_code'}</span>"
         }
         body {
             div class: "camera-container" do
@@ -255,13 +241,13 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 end
                 div id: "selector-container", style: "display: none;" do
                     wform id: "camera_form" do
-                        dropdown "cameras", t(_strings, "select_camera"), [], id: "camera-selector"
+                        dropdown "cameras", "#{_strings.dig('select_camera', 'en') || 'select_camera'}", [], id: "camera-selector"
                     end
                 end
             end
         }
         footer do
-            block_button t(_strings, "close_button"), id: "scan-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "scan-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#scan-modal').modal('hide');"
             end
         end
@@ -269,29 +255,29 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "search-help-modal" do
         header {
-            h4 s(_strings, "search_help_title"), id: "search-help-modal-title"
+            h4 "<span data-i18n=\"search_help_title\">#{_strings.dig('search_help_title', 'en') || 'search_help_title'}</span>", id: "search-help-modal-title"
         }
         body {
             div id: "search-help-modal-body" do
                 code "artist:"
                 p do
-                    span s(_strings, "search_help_artist")
+                    span "<span data-i18n=\"search_help_artist\">#{_strings.dig('search_help_artist', 'en') || 'search_help_artist'}</span>"
                     code "artist:yoasobi"
                 end
                 code "genre:"
                 p do
-                    span s(_strings, "search_help_genre")
+                    span "<span data-i18n=\"search_help_genre\">#{_strings.dig('search_help_genre', 'en') || 'search_help_genre'}</span>"
                     code "genre:アニメ"
                 end
                 code "type:"
                 p do
-                    span s(_strings, "search_help_type")
+                    span "<span data-i18n=\"search_help_type\">#{_strings.dig('search_help_type', 'en') || 'search_help_type'}</span>"
                     code "type:vocaloid"
                 end
             end
         }
         footer do
-            block_button t(_strings, "close_button"), id: "search-help-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "search-help-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#search-help-modal').modal('hide');"
             end
         end
@@ -306,7 +292,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button t(_strings, "add_to_queue_button"), id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
+            block_button "#{_strings.dig('add_to_queue_button', 'en') || 'add_to_queue_button'}", id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
                 script "queue_song($('#current-song-code').text())"
             end
             normal_button :heart, nil, style: "default", id: "favourite-button" do
@@ -317,11 +303,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "info-modal" do
         header {
-            h4 s(_strings, "info_modal_title"), id: "info-modal-title"
+            h4 "<span data-i18n=\"info_modal_title\">#{_strings.dig('info_modal_title', 'en') || 'info_modal_title'}</span>", id: "info-modal-title"
         }
         body {
             div id: "info-modal-body" do
-                h4 s(_strings, "session_status_heading")
+                h4 "<span data-i18n=\"session_status_heading\">#{_strings.dig('session_status_heading', 'en') || 'session_status_heading'}</span>"
                 p id: "connected" do
                 end
                 div id: "most-played" do
@@ -329,7 +315,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button t(_strings, "close_button"), id: "info-close-btn", "data-i18n-btn": "close_button" do
+            block_button "#{_strings.dig('close_button', 'en') || 'close_button'}", id: "info-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#info-modal').modal('hide');"
             end
         end

--- a/source/index.weave
+++ b/source/index.weave
@@ -1,4 +1,23 @@
 # vim:ft=ruby
+require 'json'
+
+# Load all UI strings from the project root
+_strings = JSON.parse(File.read(File.join(__dir__, 'strings.json')))
+
+# Helper: returns the English text for a key (used as weaver string arguments)
+# and renders a <span data-i18n="key"> so JS can swap to Japanese at runtime.
+def s(strings, key)
+  en = strings.dig(key, 'en') || key
+  "<span data-i18n=\"#{key}\">#{en}</span>"
+end
+
+# Plain English text for arguments that weaver renders as HTML attributes
+# (e.g. tab names, button labels) — weaver wraps these itself so we use spans.
+# For truly plain-text-only contexts we fall back to the English string directly.
+def t(strings, key)
+  strings.dig(key, 'en') || key
+end
+
 empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     ## HACK IOS ZOOM
@@ -7,6 +26,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     #
     # Imports
     #
+    request_js "js/i18n.js"
     request_js "js/utils.js"
     request_js "js/song.js"
     request_js "js/main.js"
@@ -26,11 +46,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
     # Content
     #
     tabs do
-        tab "Search" do
-            h4 "Song search:"
+        tab t(_strings, "tab_search") do
+            h4 s(_strings, "song_search_heading")
             wform id: "song_search_form" do
-                textfield "search", nil, placeholder: "Type to start searching", id: "search-field"
-                submit "Search", :search do
+                textfield "search", nil, placeholder: t(_strings, "search_placeholder"), id: "search-field", "data-i18n-placeholder": "search_placeholder"
+                submit t(_strings, "search_button"), :search, id: "search-button", "data-i18n-value": "search_button" do
                     script "start_search();"
                 end
                 span class: "stop-playback", css_style: "display: none;" do
@@ -45,11 +65,15 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                   { label: "Franchise", value: "franchise" }
                 ], value: "all"
             end
+            small id: "search-help" do
+                a s(_strings, "search_help_link"), href: "javascript:$('#search-help-modal').modal('show');;"
+            end
+            # wrap table in div to avoid conflicts with pagination element
             div do
                 table striped: true, id: "song-table", style: "display: none;" do
                     thead id: "song-table-head" do
-                        th { text "Title" }
-                        th { text "Artist" }
+                        th { text s(_strings, "column_title") }
+                        th { text s(_strings, "column_artist") }
                     end
                     tbody id: "song-table-body" do
                     end
@@ -57,7 +81,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             div id: "empty-search", style: "display: none;" do
                 jumbotron do
-                  span "Nothing to see here 😗"
+                  span s(_strings, "empty_search")
                 end
             end
             div id: "loader-div" do
@@ -66,12 +90,12 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "History" do
+        tab t(_strings, "tab_history") do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-history" do
                 jumbotron do
-                    p "No songs in history 🥺"
-                    span  "Queue a song to get started"
+                    p s(_strings, "empty_history_title")
+                    span s(_strings, "empty_history_subtitle")
                 end
             end
             div id: "history", style: "display: none;" do
@@ -84,12 +108,14 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
+                block_button :magic, t(_strings, "feeling_lucky"), id: "random-history", style: "none" do
+                    script "queue_random('history');"
                 end
                 table striped: true, id: "history-table" do
                     thead id: "history-table-head" do
-                        th { text "Title" }
-                        th { text "Artist" }
-                        th { text "Last Played" }
+                        th { text s(_strings, "column_title") }
+                        th { text s(_strings, "column_artist") }
+                        th { text s(_strings, "column_last_played") }
                     end
                     tbody id: "history-table-body" do
                     end
@@ -97,12 +123,12 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "Favourites" do
+        tab t(_strings, "tab_favourites") do
             # TODO: weaver can't add ids on jumbotron divs either
             div id: "empty-favourites" do
                 jumbotron do
-                    p "No songs in favourites 🥺"
-                    span  "Favourite a song to get started"
+                    p s(_strings, "empty_favourites_title")
+                    span s(_strings, "empty_favourites_subtitle")
                 end
             end
             div id: "favourites", style: "display: none;" do
@@ -115,11 +141,13 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                             script "stop_song();"
                         end
                     end
+                block_button :magic, t(_strings, "feeling_lucky"), id: "random-favourite", style: "none" do
+                    script "queue_random('favourites');"
                 end
                 table striped: true, id: "favourites-table" do
                     thead id: "favourites-table-head" do
-                        th { text "Title" }
-                        th { text "Artist" }
+                        th { text s(_strings, "column_title") }
+                        th { text s(_strings, "column_artist") }
                     end
                     tbody id: "favourites-table-body" do
                     end
@@ -127,25 +155,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         end
 
-        tab "Advanced" do
+        tab t(_strings, "tab_advanced") do
             ibox do
                 type :panel
-                title "Settings"
+                title t(_strings, "settings_title")
                 div id: "settings" do
-                    h4 "Nickname:"
+                    h4 s(_strings, "nickname_heading")
                     wform id: "nickname_form" do
                         textfield "nickname", nil, id: "nickname-field"
-                        submit "Set nickname", :check do
+                        submit t(_strings, "set_nickname_button"), :check, id: "set-nickname-button", "data-i18n-value": "set_nickname_button" do
                             script "set_nickname(false);"
                         end
                     end
-                    h4 "Options:"
+                    h4 s(_strings, "options_heading")
                     wform id: "developer_mode_form" do
-                        checkbox "developer-mode", "Enable Developer Tools"
+                        checkbox "developer-mode", t(_strings, "enable_developer_tools"), id: "developer-mode-label", "data-i18n-checkbox": "enable_developer_tools"
+                        checkbox "japanese-mode", t(_strings, "enable_japanese"), id: "japanese-mode-label", "data-i18n-checkbox": "enable_japanese"
                     end
-                    h4 "Info:"
+                    h4 s(_strings, "info_heading")
                     div do
-                        block_button nil, "Show Info", id: "show-info" do
+                        block_button nil, t(_strings, "show_info_button"), id: "show-info", "data-i18n-btn": "show_info_button" do
                             script "show_info();"
                         end
                     end
@@ -153,11 +182,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
             ibox do
                 type :panel
-                title "Queue song by code"
+                title t(_strings, "queue_song_by_code")
                 # TODO: weaver breaks when form ids contain - (changes function name)
                 wform id: "queue_code_form" do
-                    textfield "ecd", nil, placeholder: "Song code", id: "ecd-field"
-                    submit "Add to queue", :play do
+                    textfield "ecd", nil, placeholder: t(_strings, "song_code_placeholder"), id: "ecd-field", "data-i18n-placeholder": "song_code_placeholder"
+                    submit t(_strings, "add_to_queue_button"), :play, id: "add-to-queue-btn", "data-i18n-value": "add_to_queue_button" do
                         script "queue_song($('#ecd-field').val());"
                     end
                 end
@@ -165,26 +194,26 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             div id: "developer-tools" do
                 ibox do
                     type :warning
-                    block_button nil, "Clear localStorage", style: "warning" do
+                    block_button nil, t(_strings, "clear_local_storage"), id: "clear-ls-btn", style: "warning", "data-i18n-btn": "clear_local_storage" do
                         script "localStorage.clear();"
                     end
-                    block_button nil, "Clear sessionStorage", style: "warning" do
+                    block_button nil, t(_strings, "clear_session_storage"), id: "clear-ss-btn", style: "warning", "data-i18n-btn": "clear_session_storage" do
                         script "sessionStorage.clear();"
                     end
-                    title "Developer Tools"
-                    block_button nil, "Toggle Debug Mode", style: "warning" do
+                    title t(_strings, "developer_tools_title")
+                    block_button nil, t(_strings, "toggle_debug_mode"), id: "toggle-debug-btn", style: "warning", "data-i18n-btn": "toggle_debug_mode" do
                         script "toggle_debug();"
                     end
                     div id: "debug-div", style: "display: none;" do
                         # TODO: feature request to weaver to enable click on .panel-heading
                         accordion do
-                            tab "Device Info" do
+                            tab t(_strings, "device_info_tab") do
                                 pre id: "device-info"
                             end
-                            tab "sessionStorage" do
+                            tab t(_strings, "session_storage_tab") do
                                 pre id: "session-storage"
                             end
-                            tab "localStorage" do
+                            tab t(_strings, "local_storage_tab") do
                                 pre id: "local-storage"
                             end
                         end
@@ -200,17 +229,25 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
         end
         normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
             script "update_status(false);"
+    div id: "footer" do
+        div id: "button-container" do
+            block_button :qrcode, t(_strings, "scan_qr_code"), id: "scan-qr", "data-i18n-btn": "scan_qr_code" do
+                script "$('#scan-modal').modal('show'); scan_qr();"
+            end
+            normal_button :unlink, nil, id: "leave-room", style: "danger", css_style: "display: none" do
+                script "update_status(false);"
+            end
         end
     end
 
-    small "Created by <a href='https://github.com/davidsiaw/alesap-server'>astrobunny</a> and <a href='https://github.com/blankaex/alesap'>Blankaex</a>"
+    small _strings.dig('created_by', 'en'), id: "created-by", "data-i18n-html": "created_by"
 
     #
     # Modals
     #
     modal "scan-modal" do
         header {
-            h4 "Scan QR Code"
+            h4 s(_strings, "scan_qr_code")
         }
         body {
             div class: "camera-container" do
@@ -218,14 +255,44 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
                 end
                 div id: "selector-container", style: "display: none;" do
                     wform id: "camera_form" do
-                        dropdown "cameras", "Select Camera", [], id: "camera-selector"
+                        dropdown "cameras", t(_strings, "select_camera"), [], id: "camera-selector"
                     end
                 end
             end
         }
         footer do
-            block_button "Close" do
+            block_button t(_strings, "close_button"), id: "scan-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#scan-modal').modal('hide');"
+            end
+        end
+    end
+
+    modal "search-help-modal" do
+        header {
+            h4 s(_strings, "search_help_title"), id: "search-help-modal-title"
+        }
+        body {
+            div id: "search-help-modal-body" do
+                code "artist:"
+                p do
+                    span s(_strings, "search_help_artist")
+                    code "artist:yoasobi"
+                end
+                code "genre:"
+                p do
+                    span s(_strings, "search_help_genre")
+                    code "genre:アニメ"
+                end
+                code "type:"
+                p do
+                    span s(_strings, "search_help_type")
+                    code "type:vocaloid"
+                end
+            end
+        }
+        footer do
+            block_button t(_strings, "close_button"), id: "search-help-close-btn", "data-i18n-btn": "close_button" do
+                script "$('#search-help-modal').modal('hide');"
             end
         end
     end
@@ -239,7 +306,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button "Add to queue", id: "add-to-queue", style: "none" do
+            block_button t(_strings, "add_to_queue_button"), id: "add-to-queue", style: "none", "data-i18n-btn": "add_to_queue_button" do
                 script "queue_song($('#current-song-code').text())"
             end
             normal_button :heart, nil, style: "default", id: "favourite-button" do
@@ -250,11 +317,11 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
 
     modal "info-modal" do
         header {
-            h4 "Info", id: "info-modal-title"
+            h4 s(_strings, "info_modal_title"), id: "info-modal-title"
         }
         body {
             div id: "info-modal-body" do
-                h4 "Session Status:"
+                h4 s(_strings, "session_status_heading")
                 p id: "connected" do
                 end
                 div id: "most-played" do
@@ -262,7 +329,7 @@ empty_page "", "alesap.blankaex.reisen", theme: :dark do
             end
         }
         footer do
-            block_button "Close" do
+            block_button t(_strings, "close_button"), id: "info-close-btn", "data-i18n-btn": "close_button" do
                 script "$('#info-modal').modal('hide');"
             end
         end

--- a/source/strings.json
+++ b/source/strings.json
@@ -1,0 +1,82 @@
+{
+  "_comment": "Static, user-facing UI strings for the alesap frontend. Each key has en (English) and ja (Japanese) entries. Active language is controlled by localStorage key 'language' and resolved by i18n() in js/i18n.js.",
+
+  "tab_search":              { "en": "Search",      "ja": "検索" },
+  "tab_history":             { "en": "History",     "ja": "履歴" },
+  "tab_favourites":          { "en": "Favourites",  "ja": "お気に入り" },
+  "tab_advanced":            { "en": "Advanced",    "ja": "詳細設定" },
+
+  "song_search_heading":     { "en": "Song search:",            "ja": "曲を検索:" },
+  "search_placeholder":      { "en": "Type to start searching", "ja": "検索するには入力してください" },
+  "search_button":           { "en": "Search",                  "ja": "検索" },
+  "search_help_link":        { "en": "Search help",             "ja": "検索ヘルプ" },
+  "column_title":            { "en": "Title",                   "ja": "タイトル" },
+  "column_artist":           { "en": "Artist",                  "ja": "アーティスト" },
+  "column_last_played":      { "en": "Last Played",             "ja": "最終再生" },
+  "empty_search":            { "en": "Nothing to see here 😗",  "ja": "ここには何もありません 😗" },
+
+  "empty_history_title":     { "en": "No songs in history 🥺",       "ja": "履歴に曲がありません 🥺" },
+  "empty_history_subtitle":  { "en": "Queue a song to get started",  "ja": "曲をキューに追加して始めましょう" },
+  "feeling_lucky":           { "en": "I'm feeling lucky",            "ja": "おまかせ" },
+
+  "empty_favourites_title":    { "en": "No songs in favourites 🥺",      "ja": "お気に入りに曲がありません 🥺" },
+  "empty_favourites_subtitle": { "en": "Favourite a song to get started", "ja": "曲をお気に入りに追加して始めましょう" },
+
+  "settings_title":          { "en": "Settings",                "ja": "設定" },
+  "nickname_heading":        { "en": "Nickname:",               "ja": "ニックネーム:" },
+  "set_nickname_button":     { "en": "Set nickname",            "ja": "ニックネームを設定" },
+  "options_heading":         { "en": "Options:",                "ja": "オプション:" },
+  "enable_developer_tools":  { "en": "Enable Developer Tools",  "ja": "開発者ツールを有効にする" },
+  "enable_japanese":         { "en": "Use Japanese",            "ja": "日本語を使用" },
+  "info_heading":            { "en": "Info:",                   "ja": "情報:" },
+  "show_info_button":        { "en": "Show Info",               "ja": "情報を表示" },
+  "queue_song_by_code":      { "en": "Queue song by code",      "ja": "コードで曲をキューに追加" },
+  "song_code_placeholder":   { "en": "Song code",               "ja": "曲コード" },
+  "add_to_queue_button":     { "en": "Add to queue",            "ja": "キューに追加" },
+  "developer_tools_title":   { "en": "Developer Tools",         "ja": "開発者ツール" },
+  "clear_local_storage":     { "en": "Clear localStorage",      "ja": "localStorage をクリア" },
+  "clear_session_storage":   { "en": "Clear sessionStorage",    "ja": "sessionStorage をクリア" },
+  "toggle_debug_mode":       { "en": "Toggle Debug Mode",       "ja": "デバッグモードを切り替え" },
+  "device_info_tab":         { "en": "Device Info",             "ja": "デバイス情報" },
+  "session_storage_tab":     { "en": "sessionStorage",          "ja": "sessionStorage" },
+  "local_storage_tab":       { "en": "localStorage",            "ja": "localStorage" },
+
+  "scan_qr_code":            { "en": "Scan QR Code",            "ja": "QRコードをスキャン" },
+  "created_by":              {
+    "en": "Created by <a href='https://github.com/davidsiaw/alesap-server'>astrobunny</a> and <a href='https://github.com/blankaex/alesap'>Blankaex</a>",
+    "ja": "作成者: <a href='https://github.com/davidsiaw/alesap-server'>astrobunny</a> と <a href='https://github.com/blankaex/alesap'>Blankaex</a>"
+  },
+
+  "close_button":            { "en": "Close",                       "ja": "閉じる" },
+  "search_help_title":       { "en": "Search Help",                 "ja": "検索ヘルプ" },
+  "search_help_artist":      { "en": "Filter by artist, e.g. ",     "ja": "アーティストで絞り込み、例: " },
+  "search_help_genre":       { "en": "Filter by genre, e.g. ",      "ja": "ジャンルで絞り込み、例: " },
+  "search_help_type":        { "en": "Filter by content type, e.g. ", "ja": "コンテンツタイプで絞り込み、例: " },
+  "info_modal_title":        { "en": "Info",                        "ja": "情報" },
+  "session_status_heading":  { "en": "Session Status:",             "ja": "セッション状態:" },
+  "most_played_heading":     { "en": "Most Played:",                "ja": "最も再生された曲:" },
+
+  "field_title":             { "en": "Title",       "ja": "タイトル" },
+  "field_artist":            { "en": "Artist",      "ja": "アーティスト" },
+  "field_genre":             { "en": "Genre",       "ja": "ジャンル" },
+  "field_info":              { "en": "Info",        "ja": "情報" },
+  "field_lyrics":            { "en": "Lyrics",      "ja": "歌詞" },
+  "field_play_count":        { "en": "Play Count",  "ja": "再生回数" },
+  "field_code":              { "en": "Code",        "ja": "コード" },
+  "debugging_info_heading":  { "en": "Debugging info:", "ja": "デバッグ情報:" },
+
+  "select_camera":           { "en": "Select Camera", "ja": "カメラを選択" },
+
+  "toast_sent_to_queue":     { "en": "Sent to queue",       "ja": "キューに送信しました" },
+  "toast_not_connected":     { "en": "Not connected",       "ja": "接続されていません" },
+  "toast_invalid_song_code": { "en": "Invalid song code",   "ja": "無効な曲コードです" },
+  "toast_sent_stop_request": { "en": "Sent stop request",   "ja": "停止リクエストを送信しました" },
+  "toast_connected":         { "en": "Connected",           "ja": "接続しました" },
+  "toast_invalid_qr":        { "en": "Invalid QR Code",     "ja": "無効なQRコードです" },
+  "toast_nickname_saved":    { "en": "Nickname saved",      "ja": "ニックネームを保存しました" },
+  "toast_debug_enabled":     { "en": "🐞 Debugging Enabled", "ja": "🐞 デバッグ有効" },
+  "toast_not_connected_long":{ "en": "Not connected—scan QR code to get started", "ja": "未接続—QRコードをスキャンして開始してください" },
+
+  "status_connected_on":     { "en": "Connected on {date}", "ja": "{date} に接続" },
+  "status_not_connected":    { "en": "Not Connected",       "ja": "未接続" }
+}


### PR DESCRIPTION
Extracts all user-facing UI strings to `source/strings.json` (with `en` and `ja` entries for each), adds a runtime i18n system via `js/i18n.js`, and wires up a **Use Japanese** checkbox in the Advanced tab that persists the language preference to `localStorage`.

### Changes
- `source/strings.json` — 66 i18n keys, each with English and Japanese translations
- `js/i18n.js` — `load_strings()`, `i18n(key, vars)`, and `apply_translations()` helpers
- `source/index.weave` — loads strings at build time via Ruby; static strings rendered as `<span data-i18n="key">` for runtime substitution; adds Use Japanese checkbox
- `js/main.js` — bootstraps i18n on startup, wires language checkbox to `localStorage`
- `js/controls.js`, `js/session.js`, `js/settings.js`, `js/utils.js` — all hard-coded UI strings replaced with `i18n()` calls
- `deploy.sh` — copies `source/strings.json` to build root